### PR TITLE
Cache control support

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ res.setHeader('etag', '1')
 This will enable browser clients to keep a copy of the cache on their side, but still being forced to validate 
 the cache state on the server before using the cached response, therefore supporting gateway based cache invalidation. 
 
-> NOTE: In order to fetch the generated `Cache-Control` and `ETag` headers, there have to be at least cache hit.
+> NOTE: In order to fetch the generated `Cache-Control` and `ETag` headers, there have to be at least cache hit.
 
 ### Invalidating caches 
 Services can easily expire cache entries on demand, i.e: when the data state changes. Here we use the `x-cache-expire` header to indicate the cache entries to expire using a matching pattern:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # http-cache-middleware
-High performance connect-like HTTP cache middleware for Node.js. 
+High performance connect-like HTTP cache middleware for Node.js. So your latency can decrease to single digit milliseconds 🚀 
 
 > Uses `cache-manager` as caching layer, so multiple
 storage engines are supported, i.e: Memory, Redis, ... https://www.npmjs.com/package/cache-manager

--- a/README.md
+++ b/README.md
@@ -77,7 +77,32 @@ service.get('/numbers', (req, res) => {
 })
 ```
 
-### Invalidating caches
+### Caching on the browser side (304 status codes)
+> From version `1.2.x` you can also use the HTTP compatible `Cache-Control` header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+When using the Cache-Control header, you can omit the custom `x-cache-timeout` header as the timeout can be passed using the `max-age` directive. 
+
+#### Direct usage: 
+```js 
+res.setHeader('cache-control', `private, no-cache, max-age=${60 * 5}`) 
+res.setHeader('etag', '1')
+
+res.end('5 minutes cacheable content here....')
+```
+
+#### Indirect usage:
+When using:
+```js
+res.setHeader('x-cache-timeout', '5 minutes')
+```
+The middleware will now transparently generate default `Cache-Control` and `ETag` headers as described below:
+```js 
+res.setHeader('cache-control', `private, no-cache, max-age=300`) 
+res.setHeader('etag', '1')
+```
+This will enable browser clients to keep a copy of the cache on their side, but still being forced to validate 
+the cache state on the server before using the cached response, therefore supporting gateway based cache invalidation.  
+
+### Invalidating caches 
 Services can easily expire cache entries on demand, i.e: when the data state changes. Here we use the `x-cache-expire` header to indicate the cache entries to expire using a matching pattern:
 ```js
 res.setHeader('x-cache-expire', '*/numbers')

--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ res.setHeader('cache-control', 'private, no-cache, max-age=300')
 res.setHeader('etag', '1')
 ```
 This will enable browser clients to keep a copy of the cache on their side, but still being forced to validate 
-the cache state on the server before using the cached response, therefore supporting gateway based cache invalidation.  
+the cache state on the server before using the cached response, therefore supporting gateway based cache invalidation. 
+
+> NOTE: In order to fetch the generated `Cache-Control` and `ETag` headers, there have to be at least cache hit.
 
 ### Invalidating caches 
 Services can easily expire cache entries on demand, i.e: when the data state changes. Here we use the `x-cache-expire` header to indicate the cache entries to expire using a matching pattern:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ When using the Cache-Control header, you can omit the custom `x-cache-timeout` h
 
 #### Direct usage: 
 ```js 
-res.setHeader('cache-control', `private, no-cache, max-age=${60 * 5}`) 
+res.setHeader('cache-control', 'private, no-cache, max-age=300')
 res.setHeader('etag', '1')
 
 res.end('5 minutes cacheable content here....')
@@ -96,7 +96,7 @@ res.setHeader('x-cache-timeout', '5 minutes')
 ```
 The middleware will now transparently generate default `Cache-Control` and `ETag` headers as described below:
 ```js 
-res.setHeader('cache-control', `private, no-cache, max-age=300`) 
+res.setHeader('cache-control', 'private, no-cache, max-age=300')
 res.setHeader('etag', '1')
 ```
 This will enable browser clients to keep a copy of the cache on their side, but still being forced to validate 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ res.setHeader('etag', '1')
 This will enable browser clients to keep a copy of the cache on their side, but still being forced to validate 
 the cache state on the server before using the cached response, therefore supporting gateway based cache invalidation. 
 
-> NOTE: In order to fetch the generated `Cache-Control` and `ETag` headers, there have to be at least cache hit.
+> NOTE: In order to fetch the generated `Cache-Control` and `ETag` headers, there have to be at least one cache hit.
 
 ### Invalidating caches 
 Services can easily expire cache entries on demand, i.e: when the data state changes. Here we use the `x-cache-expire` header to indicate the cache entries to expire using a matching pattern:

--- a/demos/basic.js
+++ b/demos/basic.js
@@ -10,11 +10,19 @@ service.get('/cache-on-get', (req, res) => {
   }, 50)
 })
 
+service.get('/cache-control', (req, res) => {
+  setTimeout(() => {
+    // keep response in cache for 1 minute if not expired before
+    res.setHeader('cache-control', 'private, no-cache, max-age=60')
+    res.send('this supposed to be a cacheable response')
+  }, 50)
+})
+
 service.delete('/cache', (req, res) => {
   // ... the logic here changes the cache state
 
   // expire the cache keys using pattern
-  res.setHeader('x-cache-expire', '*/cache-on-get')
+  res.setHeader('x-cache-expire', '*/cache-*')
   res.end()
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "http-cache-middleware",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -144,6 +144,11 @@
       "requires": {
         "defer-to-connect": "^1.0.1"
       }
+    },
+    "@tusbar/cache-control": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@tusbar/cache-control/-/cache-control-0.3.1.tgz",
+      "integrity": "sha512-qeQhWoHQqDdW+SS1TgybdOeaSo+8tZx4ZesMY0+HSLeWWa2bGDetB9wxAT/umlXuutC6QdbADd48RJ6hrYr4BQ=="
     },
     "acorn": {
       "version": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-cache-middleware",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "HTTP Cache Middleware",
   "main": "index.js",
   "scripts": {
@@ -30,6 +30,7 @@
     "standard": "^12.0.1"
   },
   "dependencies": {
+    "@tusbar/cache-control": "^0.3.1",
     "cache-manager": "^2.9.1",
     "matcher": "^2.0.0",
     "middleware-if-unless": "^1.2.1",

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -37,8 +37,16 @@ describe('cache middleware', () => {
     server.get('/cache-buffer', (req, res) => {
       setTimeout(() => {
         res.setHeader('x-cache-timeout', '1 minute')
+        res.setHeader('etag', '1')
+        res.setHeader('cache-control', 'no-cache')
         res.send(Buffer.from('world'))
       }, 50)
+    })
+
+    server.get('/cache-control', (req, res) => {
+      res.setHeader('cache-control', 'max-age=60')
+      res.setHeader('etag', '1')
+      res.send('cache')
     })
 
     server.delete('/cache', (req, res) => {
@@ -93,6 +101,35 @@ describe('cache middleware', () => {
   it('cache hit (buffer)', async () => {
     const res = await got('http://localhost:3000/cache-buffer')
     expect(res.body).to.equal('world')
+    expect(res.headers['x-cache-hit']).to.equal('1')
+    expect(res.headers['cache-control']).to.equal('no-cache')
+    expect(res.headers['etag']).to.equal('1')
+  })
+
+  it('cache hit (buffer) - Etag', async () => {
+    const res = await got('http://localhost:3000/cache-buffer')
+    expect(res.body).to.equal('world')
+    expect(res.headers['x-cache-hit']).to.equal('1')
+    expect(res.headers['etag']).to.equal('1')
+  })
+
+  it('cache hit (buffer) - If-None-Match', async () => {
+    const res = await got('http://localhost:3000/cache-buffer', {
+      headers: {
+        'If-None-Match': '1'
+      }
+    })
+    expect(res.statusCode).to.equal(304)
+  })
+
+  it('cache create - cache-control', async () => {
+    const res = await got('http://localhost:3000/cache-control')
+    expect(res.body).to.equal('cache')
+  })
+
+  it('cache hit - cache-control', async () => {
+    const res = await got('http://localhost:3000/cache-control')
+    expect(res.body).to.equal('cache')
     expect(res.headers['x-cache-hit']).to.equal('1')
   })
 


### PR DESCRIPTION
### Caching on the browser side (304 status codes)
> From version `1.2.x` you can also use the HTTP compatible `Cache-Control` header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
When using the Cache-Control header, you can omit the custom `x-cache-timeout` header as the timeout can be passed using the `max-age` directive. 

#### Direct usage: 
```js 
res.setHeader('cache-control', 'private, no-cache, max-age=300')
res.setHeader('etag', '1')

res.end('5 minutes cacheable content here....')
```

#### Indirect usage:
When using:
```js
res.setHeader('x-cache-timeout', '5 minutes')
```
The middleware will now transparently generate default `Cache-Control` and `ETag` headers as described below:
```js 
res.setHeader('cache-control', 'private, no-cache, max-age=300')
res.setHeader('etag', '1')
```
This will enable browser clients to keep a copy of the cache on their side, but still being forced to validate 
the cache state on the server before using the cached response, therefore supporting gateway based cache invalidation.  