### PR TITLE
Fixes an issue when TTL is not found and Cache-Control is provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,11 @@ const middleware = (opts) => async (req, res, next) => {
         ttl = cacheControl(payload.headers[CACHE_CONTROL]).maxAge
       }
       if (!ttl) {
-        ttl = Math.max(ms(payload.headers[X_CACHE_TIMEOUT]), 1000) / 1000 // min value: 1 second
+        if (payload.headers[X_CACHE_TIMEOUT]) {
+          ttl = Math.max(ms(payload.headers[X_CACHE_TIMEOUT]), 1000) / 1000 // min value: 1 second
+        } else {
+          return // no TTL found, we don't cache
+        }
       }
 
       // setting cache-control header if absent

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "http-cache-middleware",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -328,9 +328,9 @@
       "dev": true
     },
     "cache-manager": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-2.9.1.tgz",
-      "integrity": "sha512-xHSL/neqi9HmaJJmPetbVoIp2C+vXXr2FgfVK6ZcS9H2nXQJVvf3DPm+yD2FG4g7cQSF8l3wOzQ8eHbWcqmOaQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-2.10.0.tgz",
+      "integrity": "sha512-IuPx05r5L0uZyBDYicB2Llld1o+/1WYjoHUnrC0TNQejMAnkoYxYS9Y8Uwr+lIBytDiyu7dwwmBCup2M9KugwQ==",
       "requires": {
         "async": "1.5.2",
         "lru-cache": "4.0.0"
@@ -2600,25 +2600,12 @@
       }
     },
     "restana": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/restana/-/restana-3.2.2.tgz",
-      "integrity": "sha512-4l9WRyAmTBpmDO+o092PLvST4jcR9Bk4y+gYUiOFBpi5CScFbMvD/PYWGFJeBwgB3C0Jm5oPWP+gWNlk58q3zA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/restana/-/restana-3.2.3.tgz",
+      "integrity": "sha512-GSkBJNbRXI9YyY3xNKWxWTKQGmCc708znfu92AxqJkFVj/+U323YNIKbXE0lBDBSJUg2f0ReuAQQ6SGinxUAOw==",
       "dev": true,
       "requires": {
         "find-my-way": "^2.1.0"
-      },
-      "dependencies": {
-        "find-my-way": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-2.1.0.tgz",
-          "integrity": "sha512-Hdx6ctcrzkZH5y9EREHtXryXAgc5Bc8z5Cvoa61y9kaoYj2KU4yXD6h8b6u0NUkYPVmQQeRdf0AtG1kQxQ+ukQ==",
-          "dev": true,
-          "requires": {
-            "fast-decode-uri-component": "^1.0.0",
-            "safe-regex2": "^2.0.0",
-            "semver-store": "^0.3.0"
-          }
-        }
       }
     },
     "restore-cursor": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-cache-middleware",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "HTTP Cache Middleware",
   "main": "index.js",
   "scripts": {
@@ -26,12 +26,12 @@
     "got": "^9.6.0",
     "mocha": "^6.1.4",
     "nyc": "^14.1.1",
-    "restana": "^3.2.2",
+    "restana": "^3.2.3",
     "standard": "^12.0.1"
   },
   "dependencies": {
     "@tusbar/cache-control": "^0.3.1",
-    "cache-manager": "^2.9.1",
+    "cache-manager": "^2.10.0",
     "matcher": "^2.0.0",
     "middleware-if-unless": "^1.2.1",
     "ms": "^2.1.2",

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -43,6 +43,12 @@ describe('cache middleware', () => {
       }, 50)
     })
 
+    server.get('/cache-no-maxage', (req, res) => {
+      res.setHeader('etag', '1')
+      res.setHeader('cache-control', 'no-cache')
+      res.send('!maxage')
+    })
+
     server.get('/cache-control', (req, res) => {
       res.setHeader('cache-control', 'max-age=60')
       res.setHeader('etag', '1')
@@ -95,6 +101,13 @@ describe('cache middleware', () => {
   it('create cache (buffer)', async () => {
     const res = await got('http://localhost:3000/cache-buffer')
     expect(res.body).to.equal('world')
+    expect(res.headers['x-cache-hit']).to.equal(undefined)
+  })
+
+  it('no TTL detected', async () => {
+    await got('http://localhost:3000/cache-no-maxage')
+    const res = await got('http://localhost:3000/cache-no-maxage')
+    expect(res.body).to.equal('!maxage')
     expect(res.headers['x-cache-hit']).to.equal(undefined)
   })
 


### PR DESCRIPTION
Do not assume there will be the `maxAge` directive being set when the `Cache-Control` header is provided.